### PR TITLE
Use EvlConfig object as default export

### DIFF
--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -1,12 +1,12 @@
 import { EvlClient } from "./net/evl-client";
 import { EvlSocketConnection } from "./net/evl-connection";
-import { config } from "./config/config";
+import config from "./config/config";
 
 console.log("Welcome to EvlDaemon.");
 
-const port = config.get("port");
-const ip = config.get("ip");
-const password = config.get("password");
+const port = config.port;
+const ip = config.ip;
+const password = config.password;
 
 const evlConnection = new EvlSocketConnection(ip, port, password);
 const evlClient = new EvlClient(evlConnection);

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -1,8 +1,10 @@
 import convict from "convict";
 import { EvlConfig, Schema } from "./schema";
 
-export const config = convict<EvlConfig>(Schema);
+const config = convict<EvlConfig>(Schema);
 
 config.loadFile("./evl-daemon.json");
 
 config.validate();
+
+export default config.getProperties();


### PR DESCRIPTION
Use properties instead of keys to access config values.