### PR TITLE
Add logging infrastructure

### DIFF
--- a/src/__tests__/logging/console.test.ts
+++ b/src/__tests__/logging/console.test.ts
@@ -1,0 +1,34 @@
+import ConsoleLogger from "../../app/logging/console";
+import { LogPriority } from "../../app/logging/logger";
+import resetAllMocks = jest.resetAllMocks;
+
+const errorMock = jest.spyOn(global.console, "error").mockImplementation(() => {});
+const logMock = jest.spyOn(global.console, "log").mockImplementation(() => {});
+const logger = new ConsoleLogger(LogPriority.Debug);
+
+beforeEach(() => {
+  resetAllMocks();
+});
+
+describe("log", () => {
+  test("should log error level logs to console.error", () => {
+    logger.logError("error!");
+
+    expect(errorMock).toHaveBeenCalled();
+    expect(logMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("should log non-error level logs to console.log", () => {
+    logger.logDebug("debug!");
+
+    expect(logMock).toHaveBeenCalled();
+    expect(errorMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("should not log messages below its priority", () => {
+    logger.logTrace("trace!");
+
+    expect(logMock).toHaveBeenCalledTimes(0);
+    expect(errorMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/__tests__/net/evl-client.test.ts
+++ b/src/__tests__/net/evl-client.test.ts
@@ -9,16 +9,19 @@ import {
   LOGIN_REQUEST_PASSWORD,
   makeLoginPacket,
 } from "../../app/tpi";
+import { LogPriority, NullLogger } from "../../app/logging/logger";
 
 let evlConnection: EvlSocketConnection;
 let evlClient: EvlClient;
 let connectMock: jest.SpyInstance;
 let sendMock: jest.SpyInstance;
 
-beforeAll(() => {
-  evlConnection = new EvlSocketConnection("localhost", 4025);
+const logger = new NullLogger(LogPriority.Error);
 
-  evlClient = new EvlClient(evlConnection, "password");
+beforeAll(() => {
+  evlConnection = new EvlSocketConnection("localhost", 4025, logger);
+
+  evlClient = new EvlClient(evlConnection, "password", logger);
 
   connectMock = jest
     .spyOn(EvlSocketConnection.prototype, "connect")

--- a/src/__tests__/net/evl-client.test.ts
+++ b/src/__tests__/net/evl-client.test.ts
@@ -1,14 +1,7 @@
-import {
-  EvlConnectionEvent,
-  EvlSocketConnection,
-} from "../../app/net/evl-connection";
+import { EvlConnectionEvent, EvlSocketConnection } from "../../app/net/evl-connection";
 import { EvlClient, EvlEventNames } from "../../app/net/evl-client";
 import { Payload } from "../../app/types";
-import {
-  LOGIN_REQUEST_COMMAND,
-  LOGIN_REQUEST_PASSWORD,
-  makeLoginPacket,
-} from "../../app/tpi";
+import { LOGIN_REQUEST_COMMAND, LOGIN_REQUEST_PASSWORD, makeLoginPacket } from "../../app/tpi";
 import { LogPriority, NullLogger } from "../../app/logging/logger";
 
 let evlConnection: EvlSocketConnection;
@@ -23,13 +16,9 @@ beforeAll(() => {
 
   evlClient = new EvlClient(evlConnection, "password", logger);
 
-  connectMock = jest
-    .spyOn(EvlSocketConnection.prototype, "connect")
-    .mockImplementation(() => {});
+  connectMock = jest.spyOn(EvlSocketConnection.prototype, "connect").mockImplementation(() => {});
 
-  sendMock = jest
-    .spyOn(EvlSocketConnection.prototype, "send")
-    .mockImplementation(() => {});
+  sendMock = jest.spyOn(EvlSocketConnection.prototype, "send").mockImplementation(() => {});
 });
 
 beforeEach(() => {
@@ -76,9 +65,7 @@ describe("send", () => {
   });
 
   test("should send given data if connected", () => {
-    jest
-      .spyOn(EvlSocketConnection.prototype, "connected", "get")
-      .mockImplementation(() => true);
+    jest.spyOn(EvlSocketConnection.prototype, "connected", "get").mockImplementation(() => true);
 
     evlClient.send("data");
 
@@ -94,9 +81,7 @@ test("should send login credentials when login event received", () => {
 
   const loginPacket = makeLoginPacket("password");
 
-  jest
-    .spyOn(EvlSocketConnection.prototype, "connected", "get")
-    .mockImplementation(() => true);
+  jest.spyOn(EvlSocketConnection.prototype, "connected", "get").mockImplementation(() => true);
 
   evlConnection.emit(EvlConnectionEvent.Data, loginPayload);
 

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -2,6 +2,8 @@ import { EvlClient, EvlEventNames } from "./net/evl-client";
 import { EvlSocketConnection } from "./net/evl-connection";
 import config from "./config/config";
 import { Payload } from "./types";
+import ConsoleLogger from "./logging/console";
+import { LogPriority } from "./logging/logger";
 
 console.log("Welcome to EvlDaemon.");
 
@@ -9,8 +11,10 @@ const port = config.port;
 const ip = config.ip;
 const password = config.password;
 
-const evlConnection = new EvlSocketConnection(ip, port);
-const evlClient = new EvlClient(evlConnection, password);
+const logger = new ConsoleLogger(LogPriority.Debug);
+
+const evlConnection = new EvlSocketConnection(ip, port, logger);
+const evlClient = new EvlClient(evlConnection, password, logger);
 
 evlClient.addListener(EvlEventNames.DisconnectedEvent, (payload: Payload) => {
   console.log(`Event: ${payload.command}`);

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -17,6 +17,6 @@ const evlConnection = new EvlSocketConnection(ip, port, logger);
 const evlClient = new EvlClient(evlConnection, password, logger);
 
 evlClient.addListener(EvlEventNames.DisconnectedEvent, (payload: Payload) => {
-  console.log(`Event: ${payload.command}`);
+  logger.logTrace(`Event: ${payload.command}`);
 });
 evlClient.connect();

--- a/src/app/logging/console.ts
+++ b/src/app/logging/console.ts
@@ -1,0 +1,29 @@
+import { Logger, LogMessageParameter, LogPriority } from "./logger";
+import { format } from "util";
+
+export default class ConsoleLogger extends Logger {
+  constructor(priority: LogPriority) {
+    super(priority);
+  }
+
+  log(
+    priority: LogPriority,
+    message: string,
+    ...params: LogMessageParameter[]
+  ): void {
+    if (priority > this.priority) {
+      return;
+    }
+
+    const date = new Date(Date.now()).toISOString();
+    const formatted = format(
+      `[${LogPriority[priority]}][${date}]: ${message}`,
+      ...params,
+    );
+    if (priority === LogPriority.Error) {
+      console.error(formatted);
+    } else {
+      console.log(formatted);
+    }
+  }
+}

--- a/src/app/logging/console.ts
+++ b/src/app/logging/console.ts
@@ -6,20 +6,13 @@ export default class ConsoleLogger extends Logger {
     super(priority);
   }
 
-  log(
-    priority: LogPriority,
-    message: string,
-    ...params: LogMessageParameter[]
-  ): void {
+  log(priority: LogPriority, message: string, ...params: LogMessageParameter[]): void {
     if (priority > this.priority) {
       return;
     }
 
     const date = new Date(Date.now()).toISOString();
-    const formatted = format(
-      `[${LogPriority[priority]}][${date}]: ${message}`,
-      ...params,
-    );
+    const formatted = format(`[${LogPriority[priority]}][${date}]: ${message}`, ...params);
     if (priority === LogPriority.Error) {
       console.error(formatted);
     } else {

--- a/src/app/logging/logger.ts
+++ b/src/app/logging/logger.ts
@@ -11,11 +11,7 @@ export type LogMessageParameter = string | undefined | null;
 export abstract class Logger {
   protected constructor(protected priority: LogPriority) {}
 
-  abstract log(
-    priority: LogPriority,
-    message: string,
-    ...params: LogMessageParameter[]
-  ): void;
+  abstract log(priority: LogPriority, message: string, ...params: LogMessageParameter[]): void;
 
   logError(message: string, ...params: LogMessageParameter[]): void {
     this.log(LogPriority.Error, message, ...params);
@@ -44,12 +40,9 @@ export class NullLogger extends Logger {
   }
 
   /* eslint-disable @typescript-eslint/no-unused-vars */
-  log(
-    priority: LogPriority,
-    message: string,
-    ...params: LogMessageParameter[]
-  ): void {
+  log(priority: LogPriority, message: string, ...params: LogMessageParameter[]): void {
     return;
   }
+
   /* eslint-enable */
 }

--- a/src/app/logging/logger.ts
+++ b/src/app/logging/logger.ts
@@ -1,0 +1,55 @@
+export enum LogPriority {
+  Error,
+  Warning,
+  Info,
+  Debug,
+  Trace,
+}
+
+export type LogMessageParameter = string | undefined | null;
+
+export abstract class Logger {
+  protected constructor(protected priority: LogPriority) {}
+
+  abstract log(
+    priority: LogPriority,
+    message: string,
+    ...params: LogMessageParameter[]
+  ): void;
+
+  logError(message: string, ...params: LogMessageParameter[]): void {
+    this.log(LogPriority.Error, message, ...params);
+  }
+
+  logWarning(message: string, ...params: LogMessageParameter[]): void {
+    this.log(LogPriority.Warning, message, ...params);
+  }
+
+  logInfo(message: string, ...params: LogMessageParameter[]): void {
+    this.log(LogPriority.Info, message, ...params);
+  }
+
+  logDebug(message: string, ...params: LogMessageParameter[]): void {
+    this.log(LogPriority.Debug, message, ...params);
+  }
+
+  logTrace(message: string, ...params: LogMessageParameter[]): void {
+    this.log(LogPriority.Trace, message, ...params);
+  }
+}
+
+export class NullLogger extends Logger {
+  constructor(priority: LogPriority) {
+    super(priority);
+  }
+
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  log(
+    priority: LogPriority,
+    message: string,
+    ...params: LogMessageParameter[]
+  ): void {
+    return;
+  }
+  /* eslint-enable */
+}

--- a/src/app/net/evl-connection.ts
+++ b/src/app/net/evl-connection.ts
@@ -1,6 +1,7 @@
 import EventEmitter from "events";
 import { Socket, createConnection } from "net";
 import { getPayload } from "../tpi";
+import { Logger } from "../logging/logger";
 
 export enum EvlConnectionEvent {
   Connected = "CONNECTED",
@@ -24,18 +25,20 @@ export class EvlSocketConnection
   private _port: number;
   private _connected: boolean = false;
 
+  private _logger: Logger;
   private _socket: Socket | null;
 
   get connected(): boolean {
     return this._connected;
   }
 
-  constructor(ip: string, port: number) {
+  constructor(ip: string, port: number, logger: Logger) {
     super();
 
     this._ip = ip;
     this._port = port;
 
+    this._logger = logger;
     this._socket = null;
   }
 
@@ -62,7 +65,7 @@ export class EvlSocketConnection
 
     const written = this._socket.write(buffer, (e?) => {
       if (e) {
-        console.error(`Error while sending: ${e.message}`);
+        this._logger.logError("Error while sending: %s", e.message);
       }
     });
 
@@ -80,7 +83,7 @@ export class EvlSocketConnection
   }
 
   private handleConnectedEvent(): void {
-    console.log("Connected!");
+    this._logger.logDebug("Connected!");
     this._connected = true;
 
     this.emit(EvlConnectionEvent.Connected);
@@ -92,7 +95,7 @@ export class EvlSocketConnection
     const lastPacket = packets.pop();
 
     if (lastPacket !== "") {
-      console.error(`Received incomplete data: ${lastPacket}`);
+      this._logger.logError("Received incomplete data: %s", lastPacket);
     }
 
     packets.forEach((packet) => {


### PR DESCRIPTION
Adds a logging infrastructure that supports different logging destinations. Includes a console log implementation as well as a null logger that can be used when logging isn't required.

All usages of console.log/console.error were replaced with calls to the provided logger.