### PR TITLE
Do not use eslint for formatting concerns

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -3,19 +3,19 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   overrides: [
     {
-      files: ['*.ts', '*.tsx'], // Your TypeScript files extension
+      files: ["*.ts", "*.tsx"], // Your TypeScript files extension
       extends: [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:@typescript-eslint/recommended-type-checked",
-        "plugin:prettier/recommended",
+        "prettier",
       ],
       parserOptions: {
-        project: ['./tsconfig.json'], // Specify it only for TypeScript files
+        project: ["./tsconfig.json"], // Specify it only for TypeScript files
       },
       rules: {
         "@typescript-eslint/explicit-function-return-type": "error",
-      }
+      },
     },
   ],
   root: true,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-    "trailingComma": "all"
+  "trailingComma": "all",
+  "printWidth": 100
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@typescript-eslint/parser": "^6.19.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-prettier": "^5.1.2",
     "jest": "^29.7.0",
     "prettier": "^3.1.1",
     "ts-jest": "^29.1.2",

--- a/src/__tests__/logging/console.test.ts
+++ b/src/__tests__/logging/console.test.ts
@@ -2,9 +2,7 @@ import ConsoleLogger from "../../app/logging/console";
 import { LogPriority } from "../../app/logging/logger";
 import resetAllMocks = jest.resetAllMocks;
 
-const errorMock = jest
-  .spyOn(global.console, "error")
-  .mockImplementation(() => {});
+const errorMock = jest.spyOn(global.console, "error").mockImplementation(() => {});
 const logMock = jest.spyOn(global.console, "log").mockImplementation(() => {});
 const logger = new ConsoleLogger(LogPriority.Debug);
 

--- a/src/__tests__/net/evl-client.test.ts
+++ b/src/__tests__/net/evl-client.test.ts
@@ -1,14 +1,7 @@
 import { LogPriority, NullLogger } from "../../app/logging/logger";
 import { EvlClient, EvlEventNames } from "../../app/net/evl-client";
-import {
-  EvlConnectionEvent,
-  EvlSocketConnection,
-} from "../../app/net/evl-connection";
-import {
-  LOGIN_REQUEST_COMMAND,
-  LOGIN_REQUEST_PASSWORD,
-  makeLoginPacket,
-} from "../../app/tpi";
+import { EvlConnectionEvent, EvlSocketConnection } from "../../app/net/evl-connection";
+import { LOGIN_REQUEST_COMMAND, LOGIN_REQUEST_PASSWORD, makeLoginPacket } from "../../app/tpi";
 import { Payload } from "../../app/types";
 
 let evlConnection: EvlSocketConnection;
@@ -23,13 +16,9 @@ beforeAll(() => {
 
   evlClient = new EvlClient(evlConnection, "password", logger);
 
-  connectMock = jest
-    .spyOn(EvlSocketConnection.prototype, "connect")
-    .mockImplementation(() => {});
+  connectMock = jest.spyOn(EvlSocketConnection.prototype, "connect").mockImplementation(() => {});
 
-  sendMock = jest
-    .spyOn(EvlSocketConnection.prototype, "send")
-    .mockImplementation(() => {});
+  sendMock = jest.spyOn(EvlSocketConnection.prototype, "send").mockImplementation(() => {});
 });
 
 beforeEach(() => {
@@ -76,9 +65,7 @@ describe("send", () => {
   });
 
   test("should send given data if connected", () => {
-    jest
-      .spyOn(EvlSocketConnection.prototype, "connected", "get")
-      .mockImplementation(() => true);
+    jest.spyOn(EvlSocketConnection.prototype, "connected", "get").mockImplementation(() => true);
 
     evlClient.send("data");
 
@@ -94,9 +81,7 @@ test("should send login credentials when login event received", () => {
 
   const loginPacket = makeLoginPacket("password");
 
-  jest
-    .spyOn(EvlSocketConnection.prototype, "connected", "get")
-    .mockImplementation(() => true);
+  jest.spyOn(EvlSocketConnection.prototype, "connected", "get").mockImplementation(() => true);
 
   evlConnection.emit(EvlConnectionEvent.Data, loginPayload);
 

--- a/src/app/logging/console.ts
+++ b/src/app/logging/console.ts
@@ -6,20 +6,13 @@ export default class ConsoleLogger extends Logger {
     super(priority);
   }
 
-  log(
-    priority: LogPriority,
-    message: string,
-    ...params: LogMessageParameter[]
-  ): void {
+  log(priority: LogPriority, message: string, ...params: LogMessageParameter[]): void {
     if (priority > this.priority) {
       return;
     }
 
     const date = new Date(Date.now()).toISOString();
-    const formatted = format(
-      `[${LogPriority[priority]}][${date}]: ${message}`,
-      ...params,
-    );
+    const formatted = format(`[${LogPriority[priority]}][${date}]: ${message}`, ...params);
     if (priority === LogPriority.Error) {
       console.error(formatted);
     } else {

--- a/src/app/logging/logger.ts
+++ b/src/app/logging/logger.ts
@@ -11,11 +11,7 @@ export type LogMessageParameter = string | undefined | null;
 export abstract class Logger {
   protected constructor(protected priority: LogPriority) {}
 
-  abstract log(
-    priority: LogPriority,
-    message: string,
-    ...params: LogMessageParameter[]
-  ): void;
+  abstract log(priority: LogPriority, message: string, ...params: LogMessageParameter[]): void;
 
   logError(message: string, ...params: LogMessageParameter[]): void {
     this.log(LogPriority.Error, message, ...params);
@@ -44,11 +40,7 @@ export class NullLogger extends Logger {
   }
 
   /* eslint-disable @typescript-eslint/no-unused-vars */
-  log(
-    priority: LogPriority,
-    message: string,
-    ...params: LogMessageParameter[]
-  ): void {
+  log(priority: LogPriority, message: string, ...params: LogMessageParameter[]): void {
     return;
   }
 

--- a/src/app/net/evl-client.ts
+++ b/src/app/net/evl-client.ts
@@ -69,16 +69,12 @@ export class EvlClient extends EventEmitter implements IEvlClient {
       this.handleDataEvent(data),
     );
 
-    this._connection.addListener(
-      EvlConnectionEvent.Disconnected,
-      (hadError: boolean) => this.handleCloseEvent(hadError),
+    this._connection.addListener(EvlConnectionEvent.Disconnected, (hadError: boolean) =>
+      this.handleCloseEvent(hadError),
     );
   }
 
-  public addListener(
-    event: EvlEvent,
-    handler: EvlClientEventHandler<EvlEvent>,
-  ): this {
+  public addListener(event: EvlEvent, handler: EvlClientEventHandler<EvlEvent>): this {
     super.addListener(event, handler);
     return this;
   }
@@ -107,9 +103,7 @@ export class EvlClient extends EventEmitter implements IEvlClient {
         break;
       case LOGIN_REQUEST_TIMEOUT:
         // handle timeout
-        this._logger.logError(
-          "Device sent a timeout while waiting for password",
-        );
+        this._logger.logError("Device sent a timeout while waiting for password");
         break;
       case LOGIN_REQUEST_FAIL:
         // handle login fail

--- a/src/app/net/evl-connection.ts
+++ b/src/app/net/evl-connection.ts
@@ -17,10 +17,7 @@ export interface IEvlConnection extends EventEmitter {
   send(data: string): void;
 }
 
-export class EvlSocketConnection
-  extends EventEmitter
-  implements IEvlConnection
-{
+export class EvlSocketConnection extends EventEmitter implements IEvlConnection {
   private _ip: string;
   private _port: number;
   private _connected: boolean = false;
@@ -47,13 +44,9 @@ export class EvlSocketConnection
       return;
     }
 
-    this._socket = createConnection(this._port, this._ip, () =>
-      this.handleConnectedEvent(),
-    )
+    this._socket = createConnection(this._port, this._ip, () => this.handleConnectedEvent())
       .on("data", (data: Buffer) => this.handleDataEvent(data))
-      .on("close", (handleError: boolean) =>
-        this.handleCloseEvent(handleError),
-      );
+      .on("close", (handleError: boolean) => this.handleCloseEvent(handleError));
   }
 
   public send(data: string): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -629,11 +629,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pkgr/core@^0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
-  integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
-
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -1366,14 +1361,6 @@ eslint-config-prettier@^9.1.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
   integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
 
-eslint-plugin-prettier@^5.1.2:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz#17cfade9e732cef32b5f5be53bd4e07afd8e67e1"
-  integrity sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-    synckit "^0.8.6"
-
 eslint-scope@^7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
@@ -1504,11 +1491,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
-  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
 fast-glob@^3.2.9:
   version "3.3.2"
@@ -2554,13 +2536,6 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
-
 prettier@^3.1.1:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
@@ -2787,14 +2762,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-synckit@^0.8.6:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.8.tgz#fe7fe446518e3d3d49f5e429f443cf08b6edfcd7"
-  integrity sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==
-  dependencies:
-    "@pkgr/core" "^0.1.0"
-    tslib "^2.6.2"
-
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
@@ -2863,11 +2830,6 @@ ts-node@^10.9.2:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
-
-tslib@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Removes the usage of the eslint-plugin-prettier package so that eslint is not used for formatting. Prettier now handles all formatting concerns on its own, and conflicting eslint rules are disabled via the eslint-config-prettier package.